### PR TITLE
Cambios en role usuario y solicitud de evento

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ target/
 node_modules/
 .env
 .DS_Store
-.DS_Store
-.DS_Store
+# Agentic workspace
+.opencode/
+AGENTS.md
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -69,7 +69,6 @@
       "resolved": "https://registry.npmjs.org/@casl/ability/-/ability-6.7.3.tgz",
       "integrity": "sha512-A4L28Ko+phJAsTDhRjzCOZWECQWN2jzZnJPnROWWHjJpyMq1h7h9ZqjwS2WbIUa3Z474X1ZPSgW0f1PboZGC0A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ucast/mongo2js": "^1.3.0"
       },
@@ -3040,7 +3039,6 @@
       "integrity": "sha512-/NbVmcGTP+lj5oa4yiYxxeBjRivKQ5Ns1eSZeB99ExsEQ6rX5XYU1Zy/gGxY/ilqtD4Etx9mKyrPxZRetiahhA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.14.0"
       }
@@ -3051,7 +3049,6 @@
       "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -3062,7 +3059,6 @@
       "integrity": "sha512-9KQPoO6mZCi7jcIStSnlOWn2nEF3mNmyr3rIAsGnAbQKYbRLyqmeSc39EVgtxXVia+LMT8j3knZLAZAh+xLmrw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3126,7 +3122,6 @@
       "integrity": "sha512-6JSSaBZmsKvEkbRUkf7Zj7dru/8ZCrJxAqArcLaVMee5907JdtEbKGsZ7zNiIm/UAkpGUkaSMZEXShnN2D1HZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.1",
         "@typescript-eslint/types": "8.46.1",
@@ -3397,7 +3392,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4057,7 +4051,6 @@
       "integrity": "sha512-XyLmROnACWqSxiGYArdef1fItQd47weqB7iwtfr9JHwRrqIXZdcFMvvEcL9xHCmL0SNsOvF0c42lWyM1U5dgig==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5386,6 +5379,7 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.12.1.tgz",
       "integrity": "sha512-l8386ixSsBdbreOAkqtrwqHwdvR35ID8c3rKPa8lCWuO86dBi32QWHV4vfsZK1utLLFMvw+Z5Ad4XLkZzchscg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -5443,7 +5437,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5453,7 +5446,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5466,7 +5458,6 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.65.0.tgz",
       "integrity": "sha512-xtOzDz063WcXvGWaHgLNrNzlsdFgtUWcb32E6WFaGTd7kPZG3EeDusjdZfUsPwKCKVXy1ZlntifaHZ4l8pAsmw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -5490,7 +5481,6 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -5647,8 +5637,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -6016,7 +6005,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6131,7 +6119,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6271,7 +6258,6 @@
       "integrity": "sha512-CmuvUBzVJ/e3HGxhg6cYk88NGgTnBoOo7ogtfJJ0fefUWAxN/WDSUa50o+oVBxuIhO8FoEZW0j2eW7sfjs5EtA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -6365,7 +6351,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/frontend/src/components/app-sidebar.tsx
+++ b/frontend/src/components/app-sidebar.tsx
@@ -16,6 +16,7 @@ import { Badge } from "@/components/ui/badge";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import logo from "@/assets/unla-logo.svg";
 import { useRole } from "@/hooks/useRole";
+import { useCan } from "@/hooks/useCan";
 
 interface NavigationItem {
   label: string;
@@ -23,32 +24,6 @@ interface NavigationItem {
   icon: LucideIcon;
   badge?: string;
 }
-
-const primaryNavigation: NavigationItem[] = [
-  { label: "Dashboard", to: "/dashboard", icon: LayoutDashboard },
-  { label: "Calendario", to: "/calendar", icon: Calendar },
-  { label: "Eventos", to: "/events", icon: ListChecks },
-  {
-    label: "Nuevo evento",
-    to: "/events/new",
-    icon: PlusCircle,
-    badge: "NEW",
-  },
-  {
-    label: "Solicitudes",
-    to: "/solicitudes",
-    icon: ClipboardList,
-  },
-];
-
-const catalogsNavigation: NavigationItem[] = [
-  { label: "Espacios", to: "/catalog/spaces", icon: Building2 },
-  { label: "Departamentos", to: "/catalog/departments", icon: MapPinned },
-];
-
-const adminNavigation: NavigationItem[] = [
-  { label: "Usuarios & Roles", to: "/admin/users", icon: Users2 },
-];
 
 interface AppSidebarProps {
   variant?: "desktop" | "drawer";
@@ -60,8 +35,35 @@ export default function AppSidebar({
   className,
 }: AppSidebarProps) {
   const { isAdminFull } = useRole();
+  const can = useCan();
   const showAdminSection = isAdminFull();
+  const canCreateEvent = can('create', 'Event');
+  const canManageCatalogs = can('manageCatalogs', 'Space');
+  const canReadPublicRequests = can('read', 'PublicRequest');
   const year = new Date().getFullYear();
+
+  const primaryNavigation: NavigationItem[] = [
+    { label: "Dashboard", to: "/dashboard", icon: LayoutDashboard },
+    { label: "Calendario", to: "/calendar", icon: Calendar },
+    { label: "Eventos", to: "/events", icon: ListChecks },
+    ...(canCreateEvent
+      ? [{ label: "Nuevo evento", to: "/events/new", icon: PlusCircle, badge: "NEW" as const }]
+      : [{ label: "Nueva solicitud", to: "/solicitud", icon: PlusCircle }]),
+    ...(canReadPublicRequests ? [{ label: "Solicitudes", to: "/solicitudes", icon: ClipboardList }] : []),
+  ];
+
+  const catalogsNavigation: NavigationItem[] = [
+    ...(canManageCatalogs
+      ? [
+          { label: "Espacios", to: "/catalog/spaces", icon: Building2 },
+          { label: "Departamentos", to: "/catalog/departments", icon: MapPinned },
+        ]
+      : []),
+  ];
+
+  const adminNavigation: NavigationItem[] = [
+    { label: "Usuarios & Roles", to: "/admin/users", icon: Users2 },
+  ];
 
   return (
     <aside
@@ -90,7 +92,9 @@ export default function AppSidebar({
       <ScrollArea className="flex-1 px-4">
         <div className="space-y-8 pb-8">
           <SidebarSection title="Menu" items={primaryNavigation} />
-          <SidebarSection title="Catálogos" items={catalogsNavigation} />
+          {catalogsNavigation.length > 0 && (
+            <SidebarSection title="Catálogos" items={catalogsNavigation} />
+          )}
           {showAdminSection ? <SidebarSection title="Administración" items={adminNavigation} /> : null}
         </div>
       </ScrollArea>

--- a/frontend/src/features/dashboard/components/QuickActions.tsx
+++ b/frontend/src/features/dashboard/components/QuickActions.tsx
@@ -16,6 +16,7 @@ import {
   CardHeader, 
   CardTitle 
 } from '@/components/ui/card';
+import { useCan } from '@/hooks/useCan';
 
 /**
  * Panel de accesos rápidos
@@ -27,6 +28,9 @@ import {
  */
 export function QuickActions() {
   const today = format(new Date(), 'yyyy-MM-dd');
+  const can = useCan();
+  const canCreateEvent = can('create', 'Event');
+  const canManageCatalogs = can('manageCatalogs', 'Space');
 
   return (
     <Card className="rounded-2xl border-slate-200 shadow-sm">
@@ -57,21 +61,23 @@ export function QuickActions() {
           variant="primary"
         />
 
-        {/* Gestionar espacios */}
-        <QuickActionButton
-          icon={MapPin}
-          label="Gestionar espacios"
-          description="Catálogo de espacios disponibles"
-          href="/catalog/spaces"
-          variant="secondary"
-        />
+        {/* Gestionar espacios - solo admins con manageCatalogs */}
+        {canManageCatalogs && (
+          <QuickActionButton
+            icon={MapPin}
+            label="Gestionar espacios"
+            description="Catálogo de espacios disponibles"
+            href="/catalog/spaces"
+            variant="secondary"
+          />
+        )}
 
-        {/* Nueva solicitud */}
+        {/* Nueva solicitud - ruta según permisos */}
         <QuickActionButton
           icon={Plus}
           label="Nueva solicitud"
-          description="Crear un nuevo evento"
-          href="/events/new"
+          description={canCreateEvent ? "Crear un nuevo evento" : "Crear una solicitud pública de evento"}
+          href={canCreateEvent ? "/events/new" : "/solicitud"}
           variant="accent"
         />
       </CardContent>

--- a/frontend/src/features/public/components/PublicEventForm.tsx
+++ b/frontend/src/features/public/components/PublicEventForm.tsx
@@ -469,7 +469,7 @@ export default function PublicEventForm() {
    * Handler de cancelar
    */
   const handleCancel = () => {
-    navigate('/login', { replace: true });
+    navigate('/', { replace: true });
   };
 
   // ========== RENDER ==========


### PR DESCRIPTION
1. app-sidebar.tsx (Sidebar/Menú lateral)
- Agregado verificación de permisos con useCan()
- "Nuevo evento" ahora cambia a "Nueva solicitud" → /solicitud para USUARIO
- Sección "Catálogos" ahora solo se muestra si el usuario tiene permiso manageCatalogs (admins)
- Sección "Solicitudes" solo visible si tiene read sobre PublicRequest

2. QuickActions.tsx (Dashboard - Accesos rápidos)
- Agregado verificación de permisos con useCan()
- "Gestionar espacios" oculto para USUARIO (solo admins ven este botón)
- "Nueva solicitud" ahora va a:
  - /events/new si tiene permiso create sobre Event (admins)
  - /solicitud si no tiene ese permiso (USUARIO)
  
3. PublicEventForm.tsx (Formulario de solicitud pública)
- Cambiado el botón "Cancelar" de /login → / (dashboard)
- Esto permite que si un usuario logueado accede a la ruta pública /solicitud, al cancelar no sea redirigido al login sino al dashboard